### PR TITLE
fix: Deploy action doesn't like a non root project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,24 +35,12 @@ jobs:
       - name: Detect package manager
         id: detect-package-manager
         run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            {
-            echo "manager=yarn";
-            echo "command=install";
-            echo "runner=yarn";
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            {
-            echo "manager=npm";
-            echo "command=ci";
-            echo "runner=npx --no-install"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
+          {
+          echo "manager=yarn";
+          echo "command=install";
+          echo "runner=yarn";
+          } >> "$GITHUB_OUTPUT"
+          exit 0
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The devops PR broke the deploy action by moving the JS project to a subdirectory. This patch replaces the version check with our known package manager, yarn.